### PR TITLE
Update ModelHandler.php line 233

### DIFF
--- a/contentify/ModelHandler.php
+++ b/contentify/ModelHandler.php
@@ -230,7 +230,7 @@ class ModelHandler
                 $tableHead[] = $title;
             }
         }
-        if (sizeof($data['actions']) > 0) {
+        if (is_array($data['actions']) && sizeof($data['actions']) > 0) {
             $tableHead[] = trans('app.actions');
         }
 


### PR DESCRIPTION
Control sizeof previous is_array. In PHP 7.2 , sizeof(null) shows an error.